### PR TITLE
Fix syntax issue

### DIFF
--- a/.ci/cirrus.runner.yml
+++ b/.ci/cirrus.runner.yml
@@ -7,7 +7,7 @@ task:
         XCODE_VERSIONS: "16.1,16,15.4,15.3,15.2,15.1,\"15.0.1\""
         DISK_SIZE: 375
       - MACOS_VERSION: sequoia
-        XCODE_VERSIONS: "16.2,\"16.3-beta-1\"16.1,16,15.4"
+        XCODE_VERSIONS: "16.2,\"16.3-beta-1\",16.1,16,15.4"
         DISK_SIZE: 350
   <<: *defaults
   pull_base_script:


### PR DESCRIPTION
Add missing comma in `XCODE_VERSIONS` list in `.ci/cirrus.runner.yml` file to fix syntax issue.